### PR TITLE
Adjust to support accessible accordions as of CiviCRM 5.69 (dropping support for older versions)

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>0.5-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.69</ver>
   </compatibility>
   <comments/>
   <civix>

--- a/js/ActivityCreation.js
+++ b/js/ActivityCreation.js
@@ -14,43 +14,42 @@
 +--------------------------------------------------------*/
 
 (function ($) {
-    let contactOriginWrapper = $('#contactOriginWrapper');
-    let accordionWrappers = $('.crm-accordion-wrapper').not(contactOriginWrapper);
+  let contactOriginWrapper = $('#contactOriginWrapper');
+  let accordionWrappers = $('details.crm-accordion-bold').not(contactOriginWrapper);
 
-    // make sure there's something there...
-    let firstAccordion = accordionWrappers[0];
-    if (!firstAccordion)
-    {
-        return;
+  // make sure there's something there...
+  if (0 === accordionWrappers) {
+    return;
+  }
+
+  // collapse other accordions, if subject is not filled yet
+  if ($('#contactorigin_subject').val()) {
+    contactOriginWrapper.addClass('collapsed');
+  }
+  else {
+    accordionWrappers.addClass('collapsed').removeAttr('open');
+  }
+
+  // insert ours at the top
+  contactOriginWrapper.insertBefore(accordionWrappers.first());
+
+  // copy campaign title into subject if selected
+  $('#contactorigin_campaign').change(function () {
+    let selected_campaign = $('#contactorigin_campaign').val();
+    if (parseInt(selected_campaign)) {
+      $('#contactorigin_subject')
+        .val(CRM.vars.contactsource.campaigns[selected_campaign])
+        .change();
     }
+  });
 
-    // collapse other accordions, if subject is not filled yet
-    if (cj("#contactorigin_subject").val()) {
-        contactOriginWrapper.addClass('collapsed');
-    } else {
-        accordionWrappers.addClass('collapsed');
+  // open main contact when fields are filled
+  $('#contactorigin_subject').change(function () {
+    if ($('#contactorigin_subject').val()) {
+      $('.crm-accordion-wrapper')
+        .not(contactOriginWrapper)
+        .first()
+        .removeClass('collapsed');
     }
-
-    // insert ours at the top
-    contactOriginWrapper.insertBefore(firstAccordion);
-
-    // copy campaign title into subject if selected
-    cj("#contactorigin_campaign").change(function() {
-        let selected_campaign = cj("#contactorigin_campaign").val();
-        if (parseInt(selected_campaign)) {
-            cj("#contactorigin_subject")
-                .val(CRM.vars.contactsource.campaigns[selected_campaign])
-                .change();
-        }
-    });
-
-    // open main contact when fields are filled
-    cj("#contactorigin_subject").change(function() {
-        if (cj("#contactorigin_subject").val()) {
-            cj('.crm-accordion-wrapper')
-                .not(contactOriginWrapper)
-                .first()
-                .removeClass('collapsed');
-        }
-    });
-})(cj);
+  });
+})(CRM.$ || cj);

--- a/templates/CRM/Contactsource/Form/ActivityCreation.tpl
+++ b/templates/CRM/Contactsource/Form/ActivityCreation.tpl
@@ -1,19 +1,19 @@
-<div id="contactOriginWrapper" class="crm-accordion-wrapper">
-  <div class="crm-accordion-header">{ts domain="de.systopia.contactsource"}Contact Source{/ts}</div>
-    <div id="contactOrigin" class="crm-accordion-body">
-      <div>
-        <table>
-          <tr>
-            <td style="border: none !important;">{$form.contactorigin_date.label}</td>
-            <td style="border: none !important;">{$form.contactorigin_campaign.label}</td>
-            <td style="border: none !important;">{$form.contactorigin_subject.label}</td>
-          </tr>
-          <tr>
-            <td style="border: none !important;">{$form.contactorigin_date.html}</td>
-            <td style="border: none !important;">{$form.contactorigin_campaign.html}</td>
-            <td style="border: none !important;">{$form.contactorigin_subject.html}</td>
-          </tr>
-        </table>
+<details id="contactOriginWrapper" class="crm-accordion-bold" open>
+  <summary class="crm-accordion-header">{ts domain="de.systopia.contactsource"}Contact Source{/ts}</summary>
+  <div id="contactOrigin" class="crm-accordion-body">
+    <div>
+      <table>
+        <tr>
+          <td>{$form.contactorigin_date.label}</td>
+          <td>{$form.contactorigin_campaign.label}</td>
+          <td>{$form.contactorigin_subject.label}</td>
+        </tr>
+        <tr>
+          <td>{$form.contactorigin_date.html}</td>
+          <td>{$form.contactorigin_campaign.html}</td>
+          <td>{$form.contactorigin_subject.html}</td>
+        </tr>
+      </table>
     </div>
   </div>
-</div>
+</details>


### PR DESCRIPTION
CiviCRM introduced accessible accordions using `details` elements instead of JavaScript-based accordion functionality, so as of that version, this extension does inject the fields in the *Create Contact* form correctly, leaving the injected fields outside of the `form` element and thus not submitting their values. This results in error messages about the injected fields being required, even when filled.

This PR adjusts the code injecting the fields and also their markup to use accessible accordions (`details` elements), dropping support for CiviCRM older than 5.69, as the newest ESR version branch is 5.75, the one before was 5.69, so dropping support for older versions seems reasonable.

*systopia-reference: 26939*